### PR TITLE
feat: Increase sidebar width to improve content readability

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,9 +20,9 @@
   --shadow-lg: 0 8px 32px rgba(22, 22, 22, 0.1);
 
   /* Spacing */
-  --container-width: 1200px;
+  --container-width: 1400px;
   --header-height: 70px;
-  --sidebar-width: 300px;
+  --sidebar-width: 500px;
   --gap: 2rem;
   --radius: 1rem;
 }

--- a/components/sidebar/sidebar.module.css
+++ b/components/sidebar/sidebar.module.css
@@ -38,11 +38,12 @@
 }
 
 .sectionTitle {
-  font-size: 1.5rem;
+  font-size: 2.5rem;
   margin-bottom: 1.5rem;
   background: var(--gradient-1);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+
 }
 
 /* Common form styles */
@@ -201,4 +202,44 @@
   transform: translateY(-2px) scale(1.05);
   box-shadow: var(--shadow-sm);
   background: var(--accent);
+}
+
+
+/* Lyrics Result styles */
+.lyricsResult {
+  margin-top: 1rem;
+  padding: 1.5rem;
+  background: var(--background);
+  border: 2px solid var(--border);
+  border-radius: 0.75rem;
+  transition: all 0.3s ease;
+}
+
+.lyricsResult h4 {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.lyricsResult pre {
+  font-family: inherit;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--foreground);
+  line-height: 1.6;
+  font-size: 0.95rem;
+  padding: 0.5rem 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+/* Error message style */
+.error {
+  color: #e53e3e;
+  background: rgba(229, 62, 62, 0.1);
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  border-left: 4px solid #e53e3e;
+  font-size: 0.875rem;
 }


### PR DESCRIPTION
Changed --sidebar-width CSS variable from 300px to 500px to provide more space for document content. This enhancement allows study notes and documentation to display with better formatting, reducing horizontal cramping for code examples and text.
- Also made the total container wider from 1200px to 1400px so all other elements look more porportionate with changes made above
- Also made the header in sidebar slightly larger- again similar reasoning to above